### PR TITLE
Introduce Game Interrupts

### DIFF
--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -1,8 +1,16 @@
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::{Card, Deck, STARTING_DECK_LEN};
 
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum Stage {
+    Lobby,
+    Playing,
+}
+
 pub struct GameData {
+    pub stage: Stage,
     pub deck: Deck,
     players: Vec<PlayerData>,
 }
@@ -10,6 +18,7 @@ pub struct GameData {
 impl GameData {
     pub fn new() -> Self {
         GameData {
+            stage: Stage::Lobby,
             deck: Deck::full(),
             players: Vec::new(),
         }
@@ -28,6 +37,8 @@ impl GameData {
     pub fn remove_player(&mut self, id: uuid::Uuid) {
         if let Some(index) = self.players.iter().position(|p| p.id() == id) {
             self.players.remove(index);
+        } else {
+            warn!("failed to remove player {id}");
         }
     }
 

--- a/src/server/disconnect.rs
+++ b/src/server/disconnect.rs
@@ -1,26 +1,40 @@
 use tokio::sync::mpsc;
 use tracing::info;
 
-use super::{config, player, GameData};
+use super::{config, player, GameData, Interrupt};
 
 pub fn handler(
     data: GameData,
+    ir_tx: mpsc::Sender<Interrupt>,
 ) -> (
     mpsc::Sender<(uuid::Uuid, player::CloseReason)>,
     mpsc::Receiver<uuid::Uuid>,
+    tokio::task::AbortHandle,
 ) {
     // listen for and remove shutdown clients
     let (shutdown, mut reasons) = mpsc::channel(config::MAX_PLAYER_COUNT);
     let (leaving, left) = mpsc::channel(1);
-    tokio::spawn({
+    let join = tokio::spawn({
         async move {
             while let Some((id, _reason)) = reasons.recv().await {
                 info!("client {id} left");
                 data.lock().remove_player(id);
                 let _ = leaving.send(id).await;
+
+                let stage = data.lock().stage;
+                match stage {
+                    crate::server::data::Stage::Lobby => (),
+                    crate::server::data::Stage::Playing => {
+                        // reset the game back when there aren't enough players to play
+                        if data.lock().player_count() < config::MIN_PLAYER_COUNT {
+                            let _ = ir_tx.send(Interrupt::Restart).await;
+                        }
+                    },
+                }
             }
         }
     });
+    let abort = join.abort_handle();
 
-    (shutdown, left)
+    (shutdown, left, abort)
 }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -3,10 +3,14 @@ use uuid::Uuid;
 
 use crate::Card;
 
-use super::data::PlayerData;
+use super::data::{PlayerData, Stage};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
+    /// The `Stage` has changed
+    StageChange(Stage),
+    /// The game has restarted
+    Restart,
     /// A player joined
     Joined {
         /// The unique id of the player
@@ -21,11 +25,9 @@ pub enum Event {
         /// The number of players in the lobby
         player_count: usize,
     },
-    /// Wait for all players to enter game
-    Starting,
     /// Start of a round
     RoundStart(usize),
-    /// Shuffle cards
+    /// Reset cards and shuffle
     Setup,
     /// Players draw their first 4 cards
     ///


### PR DESCRIPTION
# Interrupts

Allow the game control flow to be interrupted.
Interrupts are sent along a channel and listened whilst running the main game logic.

Specifically, this allows the game to be reset when the game is playing and there are too few players to continue.
This scenario can occur when one or multiple players disconnect whilst the game is playing.

