### PR TITLE
`Channels` Overhaul

### DIFF
--- a/server/src/channels.rs
+++ b/server/src/channels.rs
@@ -1,79 +1,168 @@
-use std::collections::HashMap;
-use std::future::Future;
+use std::{collections::HashMap, sync::Arc};
 
 use common::event::{client, server};
 use futures::future::JoinAll;
+use parking_lot::RwLock;
 use tokio::sync::{broadcast, mpsc};
 use tracing::trace;
 
-use crate::config;
-use crate::player::{self, Command};
+use crate::player;
+use crate::{config, player::CloseReason};
 
 pub type ClientEvents = (uuid::Uuid, client::Event);
 
+#[derive(Clone)]
+pub enum Connection {
+    Disconnect(uuid::Uuid, CloseReason),
+    Connect(uuid::Uuid),
+}
+
+enum Process {
+    Insert {
+        id: uuid::Uuid,
+        tx: mpsc::Sender<player::Command>,
+    },
+    Remove {
+        id: uuid::Uuid,
+    },
+    Send(SendTo),
+}
+
+enum SendTo {
+    All(Box<dyn Fn(uuid::Uuid) -> player::Command + Send>),
+    One(player::Command, uuid::Uuid),
+}
+
 pub struct Channels {
-    all: broadcast::Sender<player::Command>,
-    map: HashMap<uuid::Uuid, mpsc::Sender<player::Command>>,
-    event_sender: mpsc::Sender<ClientEvents>,
+    out: mpsc::Sender<Process>,
+    incoming: broadcast::Sender<ClientEvents>,
+    connections: broadcast::Sender<Connection>,
 }
 
 impl Channels {
-    pub fn new() -> (Self, mpsc::Receiver<ClientEvents>) {
-        const CHANNEL_CAPACITY: usize = 32;
+    pub fn start() -> Self {
+        const PROCESSING_CAPACITY: usize = 128;
 
-        let (all, _) = broadcast::channel(CHANNEL_CAPACITY);
-        let (event_sender, event_recv) = mpsc::channel(CHANNEL_CAPACITY);
+        let (out, out_rx) = mpsc::channel(PROCESSING_CAPACITY);
+        let (connections, _) = broadcast::channel(PROCESSING_CAPACITY);
 
-        let this = Self {
-            all,
-            map: HashMap::with_capacity(config::MIN_PLAYER_COUNT),
-            event_sender,
-        };
+        tokio::spawn(send_aggregator(out_rx));
 
-        (this, event_recv)
+        let (incoming, _) = broadcast::channel(PROCESSING_CAPACITY);
+
+        Self {
+            out,
+            incoming,
+            connections,
+        }
     }
 
-    pub fn subscribe_to_all(&self) -> broadcast::Receiver<player::Command> {
-        self.all.subscribe()
+    /// Register a new player channel, returning the sender for Client events.
+    pub async fn register(
+        &self,
+        id: uuid::Uuid,
+        tx: mpsc::Sender<player::Command>,
+    ) -> broadcast::Sender<ClientEvents> {
+        let _ = self.out.send(Process::Insert { id, tx }).await;
+        self.incoming.clone()
+    }
+}
+
+impl Channels {
+    pub async fn remove(&self, id: uuid::Uuid) {
+        let _ = self.out.send(Process::Remove { id }).await;
     }
 
-    pub fn event_sender(&self) -> mpsc::Sender<(uuid::Uuid, client::Event)> {
-        self.event_sender.clone()
+    pub async fn send(&self, command: player::Command, id: uuid::Uuid) {
+        let _ = self.out.send(Process::Send(SendTo::One(command, id))).await;
     }
 
-    pub fn insert(&mut self, id: uuid::Uuid, tx: mpsc::Sender<Command>) {
-        self.map.insert(id, tx);
+    pub async fn broadcast_event(&self, event: server::Event) {
+        let _ = self.broadcast_command(player::Command::Event(event)).await;
     }
 
-    pub fn remove(&mut self, id: uuid::Uuid) {
-        self.map.remove(&id);
+    pub async fn broadcast_command(&self, command: player::Command) {
+        let _ = self
+            .out
+            .send(Process::Send(SendTo::All(Box::new(move |_| {
+                command.clone()
+            }))))
+            .await;
     }
 
-    pub fn broadcast(&self, event: server::Event) {
-        self.send_all(player::Command::Event(event));
-    }
-
-    pub fn send_all(&self, command: player::Command) {
-        let _ = self.all.send(command.clone());
-        trace!("broadcasting command: `{command:?}`");
-    }
-
-    pub fn map_id<F>(&self, f: F) -> JoinAll<impl Future<Output = ()>>
+    pub async fn broadcast_map<F>(&self, f: F)
     where
-        F: Fn(uuid::Uuid) -> server::Event,
+        F: Fn(uuid::Uuid) -> player::Command + Send + 'static,
     {
-        self.map
-            .iter()
-            .filter(|(_, sender)| !sender.is_closed())
-            .map(|(id, sender)| {
-                let sender = sender.clone();
-                let id = *id;
-                let event = f(id);
-                async move {
-                    trace!("sending event: `{event:?}` to {id}");
-                    let _ = sender.send(player::Command::Event(event)).await;
-                }
-            })
-            .collect::<JoinAll<_>>()
+        let _ = self.out.send(Process::Send(SendTo::All(Box::new(f)))).await;
+    }
+}
+
+impl Channels {
+    /// Client connections and disconnections.
+    pub fn connections(&self) -> broadcast::Sender<Connection> {
+        self.connections.clone()
+    }
+
+    /// Incoming events from Client.
+    pub fn incoming(&self) -> broadcast::Receiver<ClientEvents> {
+        self.incoming.subscribe()
+    }
+}
+
+/// Maintains a map of streams corresponding to each player.
+/// Messages then can be sent to All or One player.
+///
+/// This allows `Channels` to be immutable.
+async fn send_aggregator(mut out_rx: mpsc::Receiver<Process>) {
+    // use a RwLock in the hopes that concurrent reads are performed more often than writes
+    let map = Arc::new(RwLock::new(HashMap::with_capacity(
+        config::MIN_PLAYER_COUNT,
+    )));
+
+    while let Some(proc) = out_rx.recv().await {
+        match proc {
+            Process::Send(send_to) => {
+                tokio::spawn(handle_send(Arc::clone(&map), send_to));
+            }
+            Process::Insert { id, tx } => {
+                map.write().insert(id, tx);
+            }
+            Process::Remove { id } => {
+                map.write().remove(&id);
+            }
+        }
+    }
+}
+
+async fn handle_send(
+    map: Arc<RwLock<HashMap<uuid::Uuid, mpsc::Sender<player::Command>>>>,
+    send: SendTo,
+) {
+    match send {
+        SendTo::All(cmd) => {
+            let join = map
+                .read()
+                .iter()
+                .filter(|(_, sender)| !sender.is_closed())
+                .map(|(id, sender)| {
+                    let sender = sender.clone();
+                    let id = *id;
+                    let cmd = cmd(id);
+                    async move {
+                        trace!("sending cmd: `{cmd:?}` to {id}");
+                        let _ = sender.send(cmd).await;
+                    }
+                })
+                .collect::<JoinAll<_>>();
+            join.await;
+        }
+        SendTo::One(cmd, id) => {
+            let sender = map.read().get(&id).cloned();
+            if let Some(sender) = sender {
+                trace!("sending cmd: `{cmd:?}` to {id}");
+                let _ = sender.send(cmd).await;
+            }
+        }
     }
 }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -7,9 +7,11 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::{Channels, GameData};
 
-pub fn notify_stage_change(stage: Stage, channels: &Channels, data: &mut GameData) {
+pub async fn notify_stage_change(stage: Stage, channels: &Channels, data: &mut GameData) {
     data.lock().stage = stage;
-    channels.lock().broadcast(server::Event::StageChange(stage));
+    channels
+.broadcast_event(server::Event::StageChange(stage))
+        .await;
 }
 
 pub fn host_id(data: &GameData) -> Option<uuid::Uuid> {


### PR DESCRIPTION
Create a new background task to handle and aggregate communication to player tasks.

We can now send commands to player tasks without using a broadcast channel, and instead can request a `SendTo::All` or `SendTo::One`.

This has the added benefit that the `Channels` object is now immutable, as state is managed in the new task. This means we can remove the `Mutex` surrounding the channel, requiring less locks to be reasoned about.
As we are now communicating through an mpsc channel, most functions on `Channels` are now marked as `async`.

A new `Disconnect` channel has to be added, as critical processing should first be done by the `disconnect` function, once finished the event can be broadcast to the rest of the program.