### PR TITLE
Persist IDs using handshake

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,5 +1,8 @@
 use common::{
-    event::{client, server},
+    event::{
+        client::{self, Event},
+        server,
+    },
     stream,
 };
 use futures::prelude::*;
@@ -35,35 +38,55 @@ impl GameClient {
     }
 
     async fn game_loop(&mut self) {
-        let Some(server::Event::Joined { uuid, .. }) = self.read.try_next().await.unwrap() else {
-            error!("failed to join");
+        self.write
+            .send(Event::Join(client::Join::New))
+            .await
+            .unwrap();
+
+        let Some(server::Event::AssignId { id }) = self.read.try_next().await.unwrap() else {
+            error!("failed to get ID");
             return;
         };
 
-        info!("joined lobby");
+        let read = self.read.try_next().await.unwrap();
+        let Some(server::Event::Enter) = read else {
+            error!("never received enter: {read:?}");
+            return;
+        };
 
-        let mut turn = uuid;
+        info!("entering event loop");
+
+        async fn request_lobby_info(writer: &mut stream::Write<client::Event>) {
+            writer.send(Event::GetLobbyInfo).await.unwrap();
+        }
+
+        request_lobby_info(&mut self.write).await;
+
+        let mut turn = id;
         let mut card_in_hand = None;
 
         while let Some(msg) = self.read.try_next().await.unwrap() {
             println!("GOT: {:?}", msg);
 
             match msg {
-                server::Event::Joined {
-                    player_count: capacity,
-                    ..
-                } => {
-                    if capacity >= 2 {
+                server::Event::LobbyInfo { player_count } => {
+                    if player_count >= 2 {
                         let _ = self.write.send(client::Event::Start).await;
                     }
                 }
-                server::Event::TurnStart { uuid, .. } => {
-                    turn = uuid;
+                server::Event::Joined { id: _ } => {
+                    request_lobby_info(&mut self.write).await;
                 }
-                server::Event::DrawCard(card) if turn == uuid => {
+                server::Event::Left { id: _ } => {
+                    request_lobby_info(&mut self.write).await;
+                }
+                server::Event::TurnStart { id, .. } => {
+                    turn = id;
+                }
+                server::Event::DrawCard(card) if turn == id => {
                     card_in_hand = Some(card);
                 }
-                server::Event::WaitingForDecision if turn == uuid => {
+                server::Event::WaitingForDecision if turn == id => {
                     if let Some(card) = card_in_hand.take() {
                         let valid_decisions = common::decisions::valid_set(card).into_vec();
                         // TODO: let the user choose from the vector
@@ -74,7 +97,7 @@ impl GameClient {
                             .unwrap();
                     }
                 }
-                server::Event::WaitingForSnap if turn != uuid => {
+                server::Event::WaitingForSnap if turn != id => {
                     self.write.send(client::Event::Snap).await.unwrap();
                 }
                 server::Event::ServerClosing => {

--- a/common/src/data.rs
+++ b/common/src/data.rs
@@ -28,10 +28,17 @@ impl GameData {
         self.players.len()
     }
 
-    pub fn add_player(&mut self, player: PlayerData) -> usize {
-        let index = self.players.len();
+    pub fn exists(&self, id: uuid::Uuid) -> bool {
+        self.players.iter().any(|data| data.id == id)
+    }
+
+    pub fn try_add_player(&mut self, player: PlayerData) -> bool {
+        if self.exists(player.id) {
+            return false;
+        }
+
         self.players.push(player);
-        index
+        true
     }
 
     pub fn remove_player(&mut self, id: uuid::Uuid) -> bool {

--- a/common/src/event/client.rs
+++ b/common/src/event/client.rs
@@ -4,9 +4,17 @@ use crate::decisions::Decision;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
+    Join(Join),
+    GetLobbyInfo,
     Start,
     Snap,
     Decision(Decision),
     Continue,
     Leave,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Join {
+    New,
+    Existing(uuid::Uuid),
 }

--- a/common/src/event/server.rs
+++ b/common/src/event/server.rs
@@ -9,21 +9,29 @@ use crate::data::{PlayerData, Stage};
 pub enum Event {
     /// The `Stage` has changed
     StageChange(Stage),
+    /// Ready to start serving event loop for client.
+    Enter,
     /// The game has restarted
     Restart,
+    /// Information about the lobby.
+    /// 
+    /// Can be requested any time.
+    LobbyInfo {
+        player_count: usize,
+    },
+    /// Response to client `Join` request.
+    /// 
+    /// Must not be broadcasted.
+    AssignId {
+        id: Uuid,
+    },
     /// A player joined
     Joined {
-        /// The unique id of the player
-        uuid: Uuid,
-        /// The number of players in the lobby
-        player_count: usize,
+        id: Uuid,
     },
     /// A player left
     Left {
-        /// The unique id of the player
-        uuid: Uuid,
-        /// The number of players in the lobby
-        player_count: usize,
+        id: Uuid,
     },
     /// Start of a round
     RoundStart(usize),
@@ -36,7 +44,7 @@ pub enum Event {
     /// Players view their front 2 cards
     FirstPeek(Card, Card),
     /// Turn of player has started
-    TurnStart { uuid: Uuid },
+    TurnStart { id: Uuid },
     /// Card is drawn from deck
     DrawCard(Card),
     /// Waiting for the player to make a decision

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -6,12 +6,16 @@ use std::{
     },
 };
 
-use common::{data::PlayerData, event::server};
+use common::{
+    data::PlayerData,
+    event::{client, server},
+};
+use futures::{SinkExt, StreamExt};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::mpsc,
 };
-use tracing::{info, trace};
+use tracing::{error, info, trace, warn};
 
 use crate::{
     channels::Connection,
@@ -40,7 +44,7 @@ pub async fn connect(
             while let Ok((stream, addr)) = listener.accept().await {
                 let accepting = enabled.load(Ordering::Relaxed);
                 if accepting {
-                    setup_client(stream, addr, &mut data, &channels, disconnects.clone()).await;
+                    try_connect(stream, addr, &mut data, &channels, disconnects.clone()).await;
                 } else {
                     trace!("not accepting, dropped {addr}");
                     drop(stream);
@@ -55,24 +59,14 @@ pub async fn connect(
 #[derive(Clone)]
 pub struct Disconnects(mpsc::Sender<(uuid::Uuid, CloseReason)>);
 
-pub fn disconnect(data: GameData, channels: Channels) -> (Disconnects, tokio::task::AbortHandle) {
+pub fn disconnect(channels: Channels) -> (Disconnects, tokio::task::AbortHandle) {
     let (tx, mut rx) = mpsc::channel(16);
 
     let task = tokio::spawn(async move {
         while let Some((id, reason)) = rx.recv().await {
             info!("client {id} has left");
-            let player_count = {
-                let mut data = data.lock();
-                data.remove_player(id);
-                data.player_count()
-            };
             channels.remove(id).await;
-            channels
-                .broadcast_event(server::Event::Left {
-                    uuid: id,
-                    player_count,
-                })
-                .await;
+            channels.broadcast_event(server::Event::Left { id }).await;
             // let subscribers know theres been a disconnection
             let _ = channels
                 .connections()
@@ -83,41 +77,81 @@ pub fn disconnect(data: GameData, channels: Channels) -> (Disconnects, tokio::ta
     (Disconnects(tx), task.abort_handle())
 }
 
-async fn setup_client(
+async fn try_connect(
     stream: TcpStream,
     addr: SocketAddr,
     data: &mut GameData,
     channels: &Channels,
     disconnects: Disconnects,
 ) {
-    info!("new connection from {addr}");
-    let player = PlayerData::new();
-    let player_id = player.id();
+    info!("connection from {addr}");
 
-    let player_count = {
-        let mut data = data.lock();
+    let mut connection = PlayerConn::from(stream);
 
-        data.add_player(player);
-        data.player_count()
+    // retrieve id of player
+    let Some(id) = id_handshake(data, &mut connection).await else {
+        return;
     };
 
+    // let other clients know someone has joined
+    trace!("sending join");
+    channels.broadcast_event(server::Event::Joined { id }).await;
+
+    // let subscribers know theres a new connection
+    let _ = channels.connections().send(Connection::Connect(id));
+
     // spawn a player task
-    let left = player::spawn(channels, player_id, PlayerConn::from(stream)).await;
+    let left = player::spawn(Arc::clone(data), channels, id, connection).await;
 
     // let the disconnect handler know
     tokio::spawn(async move {
         if let Ok(reason) = left.await {
-            let _ = disconnects.0.send((player_id, reason)).await;
+            let _ = disconnects.0.send((id, reason)).await;
         }
     });
 
-    // let everyone know someone has joined
+    // signal to the player that they can join the event loop
     channels
-        .broadcast_event(server::Event::Joined {
-            uuid: player_id,
-            player_count,
-        })
+        .send(player::Command::Event(server::Event::Enter), id)
         .await;
-    // let subscribers know theres a new connection
-    let _ = channels.connections().send(Connection::Connect(player_id));
+}
+
+async fn id_handshake(data: &mut GameData, connection: &mut PlayerConn) -> Option<uuid::Uuid> {
+    let Some(Ok(client::Event::Join(join))) = connection.read.next().await else {
+        warn!("connection refused as client never requested to join");
+        return None;
+    };
+
+    let id = retrieve_or_create_id(data, join);
+
+    // assign the player their id
+    if let Err(e) = connection.write.send(server::Event::AssignId { id }).await {
+        error!("failed to assign id to client: {e}");
+        return None;
+    }
+
+    Some(id)
+}
+
+fn retrieve_or_create_id(data: &mut GameData, join: client::Join) -> uuid::Uuid {
+    let create_new = || {
+        let player = PlayerData::new();
+        let id = player.id();
+
+        data.lock().try_add_player(player);
+
+        id
+    };
+
+    match join {
+        client::Join::New => create_new(),
+        client::Join::Existing(id) if !data.lock().exists(id) => {
+            warn!("client tried to connect with invalid id");
+            create_new()
+        }
+        client::Join::Existing(id) => {
+            debug_assert!(data.lock().exists(id));
+            id
+        }
+    }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -57,8 +57,7 @@ impl GameServer {
 
         let run = state::runner();
 
-        let (disconnects, disconnect_handle) =
-            client::disconnect(Arc::clone(&data), Arc::clone(&channels));
+        let (disconnects, disconnect_handle) = client::disconnect(Arc::clone(&channels));
 
         let (connect_enabled, connect_handle) = client::connect(
             self.config.clone(),

--- a/server/src/state/lobby.rs
+++ b/server/src/state/lobby.rs
@@ -39,8 +39,13 @@ pub async fn lobby(mut data: Data) -> (State, Data) {
                     }
                 }
                 // update the logged player count when someone joins or leaves
-                Ok(Connection::Disconnect(..) | Connection::Connect(..)) = connects.recv() => {
+                Ok(conn @ (Connection::Disconnect(..) | Connection::Connect(..))) = connects.recv() => {
                     trace!("Someone connected or disconnected");
+                    // when someone leaves during the lobby phase,
+                    // we remove them from the game data
+                    if let Connection::Disconnect(id, ..) = conn {
+                        game_data.lock().remove_player(id);
+                    }
                     break 'interrupt
                 }
                 // keep waiting!

--- a/server/src/state/playing.rs
+++ b/server/src/state/playing.rs
@@ -65,7 +65,7 @@ async fn play_round(
     loop {
         let turn_id = data.lock().get_player(turn).id();
         channels
-            .broadcast_event(server::Event::TurnStart { uuid: turn_id })
+            .broadcast_event(server::Event::TurnStart { id: turn_id })
             .await;
 
         let Some(card) = data.lock().deck.draw() else {


### PR DESCRIPTION
Add persistent IDs that clients can use to re-join games if they leave during the playing state.

During the lobby state, clients and their IDs are forgotten.

The game client is also re-written to accept this ID handshake.

The lobby info is now queried on demand by the client.